### PR TITLE
Mitigate property icon issue

### DIFF
--- a/ThemeConverter/ThemeConverter/TokenMappings.json
+++ b/ThemeConverter/ThemeConverter/TokenMappings.json
@@ -653,7 +653,20 @@
         "Cider&CommandMouseOver&Background",
         "Cider&ToggleSelected&Background",
         "Environment&AutoHideTabMouseOverBorder&Background",
+        "Environment&CommandBarHover&Background",
+        "Environment&CommandBarHoverOverSelected&Background",
+        "Environment&CommandBarHoverOverSelectedIcon&Background", //
         "Environment&CommandBarMenuItemMouseOver&Background",
+        "Environment&CommandBarMouseDownBackgroundBegin&Background",
+        "Environment&CommandBarMouseDownBackgroundEnd&Background",
+        "Environment&CommandBarMouseDownBackgroundMiddle&Background",
+        "Environment&CommandBarMouseDownBorder&Background",
+        "Environment&CommandBarMouseOverBackgroundBegin&Background",
+        "Environment&CommandBarMouseOverBackgroundEnd&Background",
+        "Environment&CommandBarMouseOverBackgroundGradient&Background", //
+        "Environment&CommandBarMouseOverBackgroundMiddle1&Background",
+        "Environment&CommandBarMouseOverBackgroundMiddle2&Background",
+        "Environment&CommandBarSelected&Background",
         "Environment&DebuggerDataTipActiveHighlight&Background",
         "Environment&ToolboxContentMouseOver&Background",
         "Environment&ToolboxDisabledContentMouseOver&Background",
@@ -664,25 +677,12 @@
         "StartPage&DefaultBannerLinkHover&Foreground",
         "StartPage&VideoRSSItemTitlePressed&Foreground",
         "UserNotifications&IgnoredMouseOverBackground&Background",
-        "UserNotifications&IgnoredMouseOverBorder&Background",
-        "Environment&CommandBarMouseOverBackgroundGradient&Background", //
-        "Environment&CommandBarHoverOverSelectedIcon&Background" //
+        "UserNotifications&IgnoredMouseOverBorder&Background"
       ]
     },
     {
       "VSC Token": "menubar.selectionBackground",
       "VS Token": [
-        "Environment&CommandBarHover&Background",
-        "Environment&CommandBarHoverOverSelected&Background",
-        "Environment&CommandBarMouseDownBackgroundBegin&Background",
-        "Environment&CommandBarMouseDownBackgroundEnd&Background",
-        "Environment&CommandBarMouseDownBackgroundMiddle&Background",
-        "Environment&CommandBarMouseDownBorder&Background",
-        "Environment&CommandBarMouseOverBackgroundBegin&Background",
-        "Environment&CommandBarMouseOverBackgroundEnd&Background",
-        "Environment&CommandBarMouseOverBackgroundMiddle1&Background",
-        "Environment&CommandBarMouseOverBackgroundMiddle2&Background",
-        "Environment&CommandBarSelected&Background",
         "Environment&StartPageTextControlLinkSelectedHover&Background"
       ]
     },


### PR DESCRIPTION
The white background in Properties Window is because the native UI does not support alpha channel - VSC token used was `menubar.selectionBackground`, this token fallback to `1affffff` in VSC, which is a transparent white. Changed the mapping to `menu.selectionBackground`, which falls back to `2c313a`(light theme) and `00a7f5` (dark theme) to mitigate the issue.
One Dark Pro:
![image](https://user-images.githubusercontent.com/34032260/131560848-56326a06-1bfe-47a6-a05c-e783f10effc8.png)

The other icon issue is also mitigated.
![image](https://user-images.githubusercontent.com/34032260/131561800-8577b338-145d-4604-a3fa-107149c87685.png)
It seems to be related to the inversion logic: when the background is `1affffff`, it is recognized as a light background and the icon is displayed in "dark mode". The inversion logic should consider the compound color when the background is not opaque. Will file bug in ADO.