### PR TITLE
Some refactoring

### DIFF
--- a/ThemeConverter/ThemeConverter.sln
+++ b/ThemeConverter/ThemeConverter.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThemeConverter", "ThemeConv
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThemeTests", "ThemeTests\ThemeTests.csproj", "{DBB1FE41-4D7A-46DD-8CC2-03FC634340EB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThemeConverterTests", "ThemeConverterTests\ThemeConverterTests.csproj", "{7B2AFD3A-CB0E-49C1-9302-3016529DF1E9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,14 @@ Global
 		{DBB1FE41-4D7A-46DD-8CC2-03FC634340EB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DBB1FE41-4D7A-46DD-8CC2-03FC634340EB}.Release|x86.ActiveCfg = Release|Any CPU
 		{DBB1FE41-4D7A-46DD-8CC2-03FC634340EB}.Release|x86.Build.0 = Release|Any CPU
+		{7B2AFD3A-CB0E-49C1-9302-3016529DF1E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B2AFD3A-CB0E-49C1-9302-3016529DF1E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B2AFD3A-CB0E-49C1-9302-3016529DF1E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7B2AFD3A-CB0E-49C1-9302-3016529DF1E9}.Debug|x86.Build.0 = Debug|Any CPU
+		{7B2AFD3A-CB0E-49C1-9302-3016529DF1E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B2AFD3A-CB0E-49C1-9302-3016529DF1E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B2AFD3A-CB0E-49C1-9302-3016529DF1E9}.Release|x86.ActiveCfg = Release|Any CPU
+		{7B2AFD3A-CB0E-49C1-9302-3016529DF1E9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ThemeConverter/ThemeConverter/Converter.cs
+++ b/ThemeConverter/ThemeConverter/Converter.cs
@@ -1,0 +1,447 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace ThemeConverter
+{
+    using System;
+    using System.CodeDom.Compiler;
+    using System.Collections.Generic;
+    using System.IO;
+    using Newtonsoft.Json.Linq;
+    using ThemeConverter.ColorCompiler;
+
+    public sealed class Converter
+    {
+        private static Guid DarkThemeId = new Guid("{1ded0138-47ce-435e-84ef-9ec1f439b749}");
+
+        private static Lazy<Dictionary<string, ColorKey[]>> ScopeMappings = new Lazy<Dictionary<string, ColorKey[]>>(ParseMapping.CreateScopeMapping());
+        private static Lazy<Dictionary<string, string>> CategoryGuids = new Lazy<Dictionary<string, string>>(ParseMapping.CreateCategoryGuids());
+        private static Lazy<Dictionary<string, string>> VSCTokenFallback = new Lazy<Dictionary<string, string>>(ParseMapping.CreateVSCTokenFallback());
+        private static Lazy<Dictionary<string, (float, string)>> OverlayMappings = new Lazy<Dictionary<string, (float, string)>>(ParseMapping.CreateOverlayMapping());
+
+        /// <summary>
+        /// Convert the theme file and patch the pkgdef to the target VS if specified.
+        /// </summary>
+        /// <param name="themeJsonFilePath">The VS Code theme json file path.</param>
+        /// <param name="pkgdefOutputPath">Output folder path to write the .pkgdef file to.</param>
+        /// <returns>
+        /// Full path to the theme .pkgdef file created in the <paramref name="pkgdefOutputPath"/> folder.
+        /// </returns>
+        public static string ConvertFile(string themeJsonFilePath, string pkgdefOutputPath)
+        {
+            string themeName = Path.GetFileNameWithoutExtension(themeJsonFilePath);
+
+            // Parse VS Code theme file.
+            var text = File.ReadAllText(themeJsonFilePath);
+            var jobject = JObject.Parse(text);
+            var theme = jobject.ToObject<ThemeFileContract>();
+
+            // Group colors by category.
+            var colorCategories = GroupColorsByCategory(theme);
+
+            // Compile VS theme.
+            string tempPkgdefFilePath = CompileVsTheme(themeName, theme, colorCategories);
+            try
+            {
+                // Copy pkgdef to specified folder
+                Directory.CreateDirectory(pkgdefOutputPath);
+
+                string destPkgdefFilePath = Path.Combine(pkgdefOutputPath, $"{themeName}.pkgdef");
+                File.Copy(tempPkgdefFilePath, destPkgdefFilePath, overwrite: true);
+
+                return destPkgdefFilePath;
+            }
+            finally
+            {
+                // Delete temporary file.
+                File.Delete(tempPkgdefFilePath);
+            }
+        }
+
+        public static void ValidateDataFiles(Action<string> reportFunc)
+        {
+            ParseMapping.CheckDuplicateMapping(reportFunc);
+        }
+
+        #region Compile VS Theme
+
+        /// <summary>
+        /// Generate the pkgdef from the theme.
+        /// </summary>
+        /// <param name="themeName">The name of theme.</param>
+        /// <param name="theme">The theme object from the json file.</param>
+        /// <param name="colorCategories">Colors grouped by category.</param>
+        /// <returns>Path to the generated pkgdef</returns>
+        private static string CompileVsTheme(
+           string themeName,
+           ThemeFileContract theme,
+           Dictionary<string, Dictionary<string, SettingsContract>> colorCategories)
+        {
+            using (TempFileCollection tempFileCollection = new TempFileCollection())
+            {
+                string tempThemeFile = tempFileCollection.AddExtension("vstheme");
+
+                using (var writer = new StreamWriter(tempThemeFile))
+                {
+                    writer.WriteLine($"<Themes>");
+
+                    Guid themeGuid = Guid.NewGuid();
+
+                    if (theme.Type == "dark")
+                    {
+                        writer.WriteLine($"    <Theme Name=\"{themeName}\" GUID=\"{themeGuid:B}\" FallbackId=\"{DarkThemeId:B}\">");
+                    }
+                    else // light theme will fallback to VS light theme by default
+                    {
+                        writer.WriteLine($"    <Theme Name=\"{themeName}\" GUID=\"{themeGuid:B}\">");
+                    }
+
+                    foreach (var category in colorCategories)
+                    {
+                        writer.WriteLine($"        <Category Name=\"{category.Key}\" GUID=\"{CategoryGuids.Value[category.Key]}\">");
+
+                        foreach (var color in category.Value)
+                        {
+                            if (color.Value.Foreground is not null || color.Value.Background is not null)
+                            {
+                                WriteColor(writer, color.Key, color.Value.Foreground, color.Value.Background);
+                            }
+                        }
+
+                        writer.WriteLine($"        </Category>");
+                    }
+
+                    writer.WriteLine($"    </Theme>");
+                    writer.WriteLine($"</Themes>");
+
+                }
+
+                // Compile the pkgdef
+                XmlFileReader reader = new XmlFileReader(tempThemeFile);
+                ColorManager manager = reader.ColorManager;
+
+                string tempPkgdef = tempFileCollection.AddExtension("pkgdef", keepFile: true);
+                FileWriter.SaveColorManagerToFile(manager, tempPkgdef, true);
+
+                return tempPkgdef;
+            }
+        }
+        #endregion Compile VS Theme
+
+        #region Translate VS Theme
+
+        /// <summary>
+        /// Method description.
+        /// </summary>
+        /// <param name="theme">Parameter description.</param>
+        /// <returns>Return description.</returns>
+        private static Dictionary<string, Dictionary<string, SettingsContract>> GroupColorsByCategory(ThemeFileContract theme)
+        {
+            // category -> colorKeyName => color value 
+            var colorCategories = new Dictionary<string, Dictionary<string, SettingsContract>>();
+            // category -> colorKeyName -> assigned by VSC token
+            var assignBy = new Dictionary<string, Dictionary<string, string>>();
+
+            Dictionary<string, bool> keyUsed = new Dictionary<string, bool>();
+            foreach (string key in ScopeMappings.Value.Keys)
+            {
+                keyUsed.Add(key, false);
+            }
+
+            // Add the editor colors
+            foreach (var ruleContract in theme.TokenColors)
+            {
+                foreach (var scopeName in ruleContract.ScopeNames)
+                {
+                    string[] scopes = scopeName.Split(',');
+                    foreach (var scopeRaw in scopes)
+                    {
+                        var scope = scopeRaw.Trim();
+                        foreach (string key in ScopeMappings.Value.Keys)
+                        {
+                            if (key.StartsWith(scope) && scope != "")
+                            {
+                                if (ScopeMappings.Value.TryGetValue(key, out var colorKeys))
+                                {
+                                    keyUsed[key] = true;
+                                    AssignEditorColors(colorKeys, scope, ruleContract, ref colorCategories, ref assignBy);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // for keys that were not used during hierarchical assigning, check if there's any fallback that we can use...
+            foreach (string key in keyUsed.Keys)
+            {
+                if (!keyUsed[key])
+                {
+                    if (VSCTokenFallback.Value.TryGetValue(key, out var fallbackToken))
+                    {
+                        // if the fallback is foreground, assign it like a shell color
+                        if (fallbackToken == "foreground" && theme.Colors.ContainsKey("foreground"))
+                        {
+                            if (ScopeMappings.Value.TryGetValue(key, out var colorKeys))
+                            {
+                                AssignShellColors(theme.Colors["foreground"], colorKeys, ref colorCategories);
+                            }
+                        }
+
+                        foreach (var ruleContract in theme.TokenColors)
+                        {
+                            foreach (var scopeName in ruleContract.ScopeNames)
+                            {
+                                string[] scopes = scopeName.Split(',');
+                                foreach (var scopeRaw in scopes)
+                                {
+                                    var scope = scopeRaw.Trim();
+
+                                    if ((fallbackToken.StartsWith(scope) && scope != ""))
+                                    {
+                                        if (ScopeMappings.Value.TryGetValue(key, out var colorKeys))
+                                        {
+                                            AssignEditorColors(colorKeys, scope, ruleContract, ref colorCategories, ref assignBy);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Add the shell colors
+            foreach (var color in theme.Colors)
+            {
+                if (ScopeMappings.Value.TryGetValue(color.Key.Trim(), out var colorKeyList))
+                {
+                    if (!TryGetColorValue(theme, color.Key, out string colorValue))
+                    {
+                        continue;
+                    }
+
+                    // calculate the actual border color for editor overlay colors
+                    if (OverlayMappings.Value.ContainsKey(color.Key) && TryGetColorValue(theme, OverlayMappings.Value[color.Key].Item2, out string backgroundColor))
+                    {
+                        colorValue = GetCompoundColor(colorValue, backgroundColor, OverlayMappings.Value[color.Key].Item1);
+                    }
+
+                    AssignShellColors(colorValue, colorKeyList, ref colorCategories);
+                }
+            }
+
+            return colorCategories;
+        }
+
+        private static bool TryGetColorValue(ThemeFileContract theme, string token, out string colorValue)
+        {
+            theme.Colors.TryGetValue(token, out colorValue);
+
+            string key = token;
+
+            while (colorValue == null)
+            {
+                if (VSCTokenFallback.Value.TryGetValue(key, out var fallbackToken))
+                {
+                    key = fallbackToken;
+                    theme.Colors.TryGetValue(key, out colorValue);
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            return colorValue != null;
+        }
+
+        /// <summary>
+        /// Compute what is the compound color of 2 overlayed colors with transparency
+        /// </summary>
+        /// <param name="VSOpacity">What is the opacity that VS will use when displaying this color</param>
+        /// <returns></returns>
+        private static string GetCompoundColor(string overlayColor, string baseColor, float VSOpacity = 1)
+        {
+            overlayColor = ReviseColor(overlayColor);
+            baseColor = ReviseColor(baseColor);
+            float overlayA = (float)System.Convert.ToInt32(overlayColor.Substring(0, 2), 16) / 255;
+            float overlayR = System.Convert.ToInt32(overlayColor.Substring(2, 2), 16);
+            float overlayG = System.Convert.ToInt32(overlayColor.Substring(4, 2), 16);
+            float overlayB = System.Convert.ToInt32(overlayColor.Substring(6, 2), 16);
+
+            float baseA = (float)System.Convert.ToInt32(baseColor.Substring(0, 2), 16) / 255;
+            float baseR = System.Convert.ToInt32(baseColor.Substring(2, 2), 16);
+            float baseG = System.Convert.ToInt32(baseColor.Substring(4, 2), 16);
+            float baseB = System.Convert.ToInt32(baseColor.Substring(6, 2), 16);
+
+            float R = (overlayA / VSOpacity) * overlayR + (1 - overlayA / VSOpacity) * baseA * baseR;
+            float G = (overlayA / VSOpacity) * overlayG + (1 - overlayA / VSOpacity) * baseA * baseG;
+            float B = (overlayA / VSOpacity) * overlayB + (1 - overlayA / VSOpacity) * baseA * baseB;
+
+            R = Math.Clamp(R, 0, 255);
+            G = Math.Clamp(G, 0, 255);
+            B = Math.Clamp(B, 0, 255);
+
+            return $"{(int)R:X2}{(int)G:X2}{(int)B:X2}FF";
+        }
+
+        private static void AssignEditorColors(ColorKey[] colorKeys,
+                                        string scope,
+                                        RuleContract ruleContract,
+                                        ref Dictionary<string, Dictionary<string, SettingsContract>> colorCategories,
+                                        ref Dictionary<string, Dictionary<string, string>> assignBy)
+        {
+            foreach (var colorKey in colorKeys)
+            {
+                if (!colorCategories.TryGetValue(colorKey.CategoryName, out var rulesList))
+                {
+                    rulesList = new Dictionary<string, SettingsContract>();
+                    colorCategories[colorKey.CategoryName] = rulesList;
+                }
+
+                if (!assignBy.TryGetValue(colorKey.CategoryName, out var assignList))
+                {
+                    assignList = new Dictionary<string, string>();
+                    assignBy[colorKey.CategoryName] = assignList;
+                }
+
+                if (rulesList.ContainsKey(colorKey.KeyName))
+                {
+                    if (scope.StartsWith(assignList[colorKey.KeyName]) && ruleContract.Settings.Foreground != null)
+                    {
+                        rulesList[colorKey.KeyName] = ruleContract.Settings;
+                        assignList[colorKey.KeyName] = scope;
+                    }
+                }
+                else
+                {
+                    rulesList.Add(colorKey.KeyName, ruleContract.Settings);
+                    assignList.Add(colorKey.KeyName, scope);
+                }
+            }
+        }
+
+        private static void AssignShellColors(string colorValue, ColorKey[] colorKeys, ref Dictionary<string, Dictionary<string, SettingsContract>> colorCategories)
+        {
+            foreach (var colorKey in colorKeys)
+            {
+                if (!colorCategories.TryGetValue(colorKey.CategoryName, out var rulesList))
+                {
+                    // token name to colors
+                    rulesList = new Dictionary<string, SettingsContract>();
+                    colorCategories[colorKey.CategoryName] = rulesList;
+                }
+
+                if (!rulesList.TryGetValue(colorKey.KeyName, out var colorSetting))
+                {
+                    colorSetting = new SettingsContract();
+                    rulesList.Add(colorKey.KeyName, colorSetting);
+                }
+
+                if (colorKey.isBackground)
+                {
+                    colorSetting.Background = colorValue;
+                }
+                else
+                {
+                    colorSetting.Foreground = colorValue;
+                }
+            }
+        }
+
+        #endregion Translate VS Theme
+
+        #region Write VS Theme
+
+        private static void WriteColor(StreamWriter writer, string colorKeyName, string foregroundColor, string backgroundColor)
+        {
+            writer.WriteLine($"            <Color Name=\"{colorKeyName}\">");
+
+            if (backgroundColor is not null)
+            {
+                writer.WriteLine($"                <Background Type=\"CT_RAW\" Source=\"{ReviseColor(backgroundColor)}\"/>");
+            }
+
+            if (foregroundColor is not null)
+            {
+                writer.WriteLine($"                <Foreground Type=\"CT_RAW\" Source=\"{ReviseColor(foregroundColor)}\"/>");
+            }
+
+            writer.WriteLine($"            </Color>");
+        }
+
+        private static string ReviseColor(string color)
+        {
+            var revisedColor = color.Trim('#');
+            switch (revisedColor.Length)
+            {
+                case 3:
+                    {
+                        string r = revisedColor.Substring(0, 1);
+                        string g = revisedColor.Substring(1, 1);
+                        string b = revisedColor.Substring(2, 1);
+                        revisedColor = string.Format("FF{0}{0}{1}{1}{2}{2}", r, g, b);
+                        break;
+                    }
+                case 4:
+                    {
+                        string r = revisedColor.Substring(0, 1);
+                        string g = revisedColor.Substring(1, 1);
+                        string b = revisedColor.Substring(2, 1);
+                        string a = revisedColor.Substring(3, 1);
+                        revisedColor = string.Format("{0}{0}{1}{1}{2}{2}{3}{3}", a, r, g, b);
+                        break;
+                    }
+                case 6:
+                    {
+                        revisedColor = $"FF{revisedColor}";
+                        break;
+                    }
+                case 8:
+                    {
+                        // go from RRGGBBAA to AARRGGBB
+                        revisedColor = string.Format("{0}{1}", revisedColor.Substring(6), revisedColor.Substring(0, 6));
+                        break;
+                    }
+                default:
+                    break;
+            }
+            return revisedColor;
+        }
+
+        #endregion Write VS Theme
+    }
+
+    internal sealed class ColorKey
+    {
+        public ColorKey(string categoryName, string keyName, string backgroundOrForeground)
+        {
+            this.CategoryName = categoryName;
+            this.KeyName = keyName;
+            this.Aspect = backgroundOrForeground;
+
+            if (backgroundOrForeground.Equals("Background", StringComparison.OrdinalIgnoreCase))
+            {
+                isBackground = true;
+            }
+            else
+            {
+                isBackground = false;
+            }
+        }
+
+        public string CategoryName { get; }
+
+        public string KeyName { get; }
+
+        public string Aspect { get; }
+
+        public bool isBackground { get; }
+
+        public override string ToString()
+        {
+            return this.CategoryName + "&" + this.KeyName + "&" + this.Aspect;
+        }
+    }
+}

--- a/ThemeConverter/ThemeConverter/ParseMapping.cs
+++ b/ThemeConverter/ThemeConverter/ParseMapping.cs
@@ -18,7 +18,7 @@ namespace ThemeConverter
         private static Dictionary<string, (float, string)> OverlayMapping = new Dictionary<string, (float, string)>();
         private static List<string> MappedVSTokens = new List<string>();
 
-        public static void CheckDuplicateMapping()
+        public static void CheckDuplicateMapping(Action<string> reportFunc)
         {
             var contents = System.IO.File.ReadAllText("TokenMappings.json");
             var file = JObject.Parse(contents);
@@ -37,7 +37,7 @@ namespace ThemeConverter
                 {
                     if (addedMappings.Contains(VSToken.ToString()))
                     {
-                        Console.WriteLine(key + ": " + VSToken.ToString());
+                        reportFunc(key + ": " + VSToken.ToString());
                     }
                     else
                     {
@@ -45,8 +45,6 @@ namespace ThemeConverter
                     }
                 }
             }
-
-            Console.WriteLine();
         }
 
         public static Dictionary<string, ColorKey[]> CreateScopeMapping()

--- a/ThemeConverter/ThemeConverter/Program.cs
+++ b/ThemeConverter/ThemeConverter/Program.cs
@@ -4,30 +4,14 @@
 namespace ThemeConverter
 {
     using System;
-    using System.CodeDom.Compiler;
-    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Globalization;
     using System.IO;
+    using System.Linq;
     using Mono.Options;
-    using Newtonsoft.Json.Linq;
-    using ThemeConverter.ColorCompiler;
 
-#pragma warning disable IDE0051 // Remove unused private members
     internal sealed class Program
     {
-        private static Guid DarkThemeId = new Guid("{1ded0138-47ce-435e-84ef-9ec1f439b749}");
-
-        private static string ThemeName = string.Empty;
-        private static Lazy<Dictionary<string, ColorKey[]>> ScopeMappings = new Lazy<Dictionary<string, ColorKey[]>>(ParseMapping.CreateScopeMapping());
-        private static Lazy<Dictionary<string, string>> CategoryGuids = new Lazy<Dictionary<string, string>>(ParseMapping.CreateCategoryGuids());
-        private static Lazy<Dictionary<string, string>> VSCTokenFallback = new Lazy<Dictionary<string, string>>(ParseMapping.CreateVSCTokenFallback());
-        private static Lazy<Dictionary<string, (float, string)>> OverlayMappings = new Lazy<Dictionary<string, (float, string)>>(ParseMapping.CreateOverlayMapping());
-
-        /// <summary>
-        /// args[0]: path to the json
-        /// args[1]: installation path to the target instance or null
-        /// </summary>
-        /// <param name="args"></param>
         static int Main(string[] args)
         {
             try
@@ -52,8 +36,7 @@ namespace ThemeConverter
                     return 0;
                 }
 
-                // Check for duplicate mappings
-                ParseMapping.CheckDuplicateMapping();
+                Converter.ValidateDataFiles((error) => Console.WriteLine(error));
 
                 if (inputPath == null || !IsValidPath(inputPath))
                 {
@@ -69,7 +52,6 @@ namespace ThemeConverter
                 {
                     throw new ApplicationException(Resources.TargetVSNotExistException);
                 }
-
 
                 Convert(inputPath, outputPath, targetVS);
 
@@ -93,37 +75,28 @@ namespace ThemeConverter
             return Directory.Exists(path) || File.Exists(path);
         }
 
-        private static void ShowHelpText()
-        {
-            try
-            {
-                Console.WriteLine(Resources.HelpHeader);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex);
-            }
-        }
-
         private static void Convert(string sourcePath, string pkgdefOutputPath, string deployInstall)
         {
-            if (Directory.Exists(sourcePath))
-            {
-                bool converted = false;
-                foreach (var sourceFile in Directory.EnumerateFiles(sourcePath, "*.json"))
-                {
-                    ConvertFile(sourceFile, pkgdefOutputPath, deployInstall);
-                    converted = true;
-                }
+            var sourceFiles = Directory.Exists(sourcePath)
+                ? Directory.EnumerateFiles(sourcePath, "*.json")
+                : Enumerable.Repeat(sourcePath, 1);
 
-                if (!converted)
-                {
-                    throw new ApplicationException(Resources.NoJSONFoundException);
-                }
-            }
-            else
+            if (!sourceFiles.Any())
             {
-                ConvertFile(sourcePath, pkgdefOutputPath, deployInstall);
+                throw new ApplicationException(Resources.NoJSONFoundException);
+            }
+
+            foreach (var sourceFile in sourceFiles)
+            {
+                Console.WriteLine($"Converting {sourceFile}");
+                Console.WriteLine();
+
+                string pkgdefFilePath = Converter.ConvertFile(sourceFile, pkgdefOutputPath);
+                if (!string.IsNullOrEmpty(deployInstall))
+                {
+                    string deployFilePath = Path.Combine(deployInstall, @"Common7\IDE\CommonExtensions\Platform", Path.GetFileName(pkgdefFilePath));
+                    File.Copy(pkgdefFilePath, deployFilePath, overwrite: true);
+                }
             }
 
             if (!string.IsNullOrEmpty(deployInstall))
@@ -132,437 +105,23 @@ namespace ThemeConverter
             }
         }
 
-        /// <summary>
-        /// Convert the theme file and patch the pkgdef to the target VS if specified.
-        /// </summary>
-        /// <param name="filePath">Theme file path</param>
-        /// <param name="pkgdefOutputPath">Output path</param>
-        /// <param name="deployInstall">Installation path to the taget VS</param>
-        private static void ConvertFile(string filePath, string pkgdefOutputPath, string deployInstall)
-        {
-            Console.WriteLine($"Converting {filePath}");
-            Console.WriteLine();
-
-            string fileName = Path.GetFileName(filePath);
-            int extensionStart = fileName.LastIndexOf(".");
-            ThemeName = fileName.Substring(0, extensionStart);
-
-            // Parse VS Code theme file.
-            var text = File.ReadAllText(filePath);
-            var jobject = JObject.Parse(text);
-            var theme = jobject.ToObject<ThemeFileContract>();
-
-            // Group colors by category.
-            var colorCategories = GroupColorsByCategory(theme);
-
-            // Compile VS theme.
-            string pkgdefFilePath = CompileVsTheme(theme, colorCategories);
-
-            // Deploy pkgdef to specified folder
-            if (!string.IsNullOrEmpty(pkgdefOutputPath))
-            {
-                Directory.CreateDirectory(pkgdefOutputPath);
-                File.Copy(pkgdefFilePath, Path.Combine(pkgdefOutputPath, $"{ThemeName}.pkgdef"), overwrite: true);
-            }
-
-            if (!string.IsNullOrEmpty(deployInstall))
-            {
-                File.Copy(pkgdefFilePath, Path.Combine(deployInstall, $@"Common7\IDE\CommonExtensions\Platform\{ThemeName}.pkgdef"), overwrite: true);
-            }
-        }
-
-        #region Compile VS Theme
-
-        /// <summary>
-        /// Generate the pkgdef from the theme.
-        /// </summary>
-        /// <param name="theme">The theme object from the json file</param>
-        /// <param name="colorCategories">Colors grouped by category</param>
-        /// <returns>Path to the generated pkgdef</returns>
-        private static string CompileVsTheme(
-           ThemeFileContract theme,
-           Dictionary<string, Dictionary<string, SettingsContract>> colorCategories)
-        {
-            using (TempFileCollection tempFileCollection = new TempFileCollection())
-            {
-                string tempThemeFile = tempFileCollection.AddExtension("vstheme");
-
-                using (var writer = new StreamWriter(tempThemeFile))
-                {
-                    writer.WriteLine($"<Themes>");
-
-                    Guid themeGuid = Guid.NewGuid();
-
-                    if (theme.Type == "dark")
-                    {
-                        writer.WriteLine($"    <Theme Name=\"{ThemeName}\" GUID=\"{themeGuid:B}\" FallbackId=\"{DarkThemeId:B}\">");
-                    }
-                    else // light theme will fallback to VS light theme by default
-                    {
-                        writer.WriteLine($"    <Theme Name=\"{ThemeName}\" GUID=\"{themeGuid:B}\">");
-                    }
-
-                    foreach (var category in colorCategories)
-                    {
-                        writer.WriteLine($"        <Category Name=\"{category.Key}\" GUID=\"{CategoryGuids.Value[category.Key]}\">");
-
-                        foreach (var color in category.Value)
-                        {
-                            if (color.Value.Foreground is not null || color.Value.Background is not null)
-                            {
-                                WriteColor(writer, color.Key, color.Value.Foreground, color.Value.Background);
-                            }
-                        }
-
-                        writer.WriteLine($"        </Category>");
-                    }
-
-                    writer.WriteLine($"    </Theme>");
-                    writer.WriteLine($"</Themes>");
-
-                }
-
-                // Compile the pkgdef
-                XmlFileReader reader = new XmlFileReader(tempThemeFile);
-                ColorManager manager = reader.ColorManager;
-
-                string tempPkgdef = tempFileCollection.AddExtension("pkgdef", keepFile: true);
-                FileWriter.SaveColorManagerToFile(manager, tempPkgdef, true);
-
-                return tempPkgdef;
-            }
-        }
-
         private static void LaunchVS(string deployInstall)
         {
             string vsPath = Path.Combine(deployInstall, @"Common7\IDE\devenv.exe");
-            var updateConfigProcess = Process.Start(vsPath, "/updateconfiguration");
-            Console.WriteLine("Running UpdateConfiguration.");
+            if (!File.Exists(vsPath))
+                throw new ApplicationException(String.Format(CultureInfo.CurrentUICulture, Resources.TargetDevEnvNotExistException, vsPath));
+
+            Console.WriteLine(Resources.RunningUpdateConfiguration);
             Console.WriteLine();
+
+            var updateConfigProcess = Process.Start(vsPath, "/updateconfiguration");
             updateConfigProcess.WaitForExit();
             if (updateConfigProcess.ExitCode != 0)
-                throw new ApplicationException("Fatal error running devenv.exe /updateconfiguration");
+                throw new ApplicationException(Resources.UpdateConfigurationException);
 
-            // Launch Visual Studio to the themes page.
-            Console.WriteLine("Launching Visual Studio.");
+            // Launch Visual Studio.
+            Console.WriteLine(Resources.LaunchingVS);
             Process.Start(vsPath);
-        }
-        #endregion Compile VS Theme
-
-        #region Translate VS Theme
-
-        /// <summary>
-        /// Method description.
-        /// </summary>
-        /// <param name="theme">Parameter description.</param>
-        /// <returns>Return description.</returns>
-        private static Dictionary<string, Dictionary<string, SettingsContract>> GroupColorsByCategory(ThemeFileContract theme)
-        {
-            // category -> colorKeyName => color value 
-            var colorCategories = new Dictionary<string, Dictionary<string, SettingsContract>>();
-            // category -> colorKeyName -> assigned by VSC token
-            var assignBy = new Dictionary<string, Dictionary<string, string>>();
-
-            Dictionary<string, bool> keyUsed = new Dictionary<string, bool>();
-            foreach (string key in ScopeMappings.Value.Keys)
-            {
-                keyUsed.Add(key, false);
-            }
-
-            // Add the editor colors
-            foreach (var ruleContract in theme.TokenColors)
-            {
-                foreach (var scopeName in ruleContract.ScopeNames)
-                {
-                    string[] scopes = scopeName.Split(',');
-                    foreach (var scopeRaw in scopes)
-                    {
-                        var scope = scopeRaw.Trim();
-                        foreach (string key in ScopeMappings.Value.Keys)
-                        {
-                            if (key.StartsWith(scope) && scope != "")
-                            {
-                                if (ScopeMappings.Value.TryGetValue(key, out var colorKeys))
-                                {
-                                    keyUsed[key] = true;
-                                    AssignEditorColors(colorKeys, scope, ruleContract, ref colorCategories, ref assignBy);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // for keys that were not used during hierarchical assigning, check if there's any fallback that we can use...
-            foreach (string key in keyUsed.Keys)
-            {
-                if (!keyUsed[key])
-                {
-                    if (VSCTokenFallback.Value.TryGetValue(key, out var fallbackToken))
-                    {
-                        // if the fallback is foreground, assign it like a shell color
-                        if (fallbackToken == "foreground" && theme.Colors.ContainsKey("foreground"))
-                        {
-                            if (ScopeMappings.Value.TryGetValue(key, out var colorKeys))
-                            {
-                                AssignShellColors(theme.Colors["foreground"], colorKeys, ref colorCategories);
-                            }
-                        }
-
-                        foreach (var ruleContract in theme.TokenColors)
-                        {
-                            foreach (var scopeName in ruleContract.ScopeNames)
-                            {
-                                string[] scopes = scopeName.Split(',');
-                                foreach (var scopeRaw in scopes)
-                                {
-                                    var scope = scopeRaw.Trim();
-
-                                    if ((fallbackToken.StartsWith(scope) && scope != ""))
-                                    {
-                                        if (ScopeMappings.Value.TryGetValue(key, out var colorKeys))
-                                        {
-                                            AssignEditorColors(colorKeys, scope, ruleContract, ref colorCategories, ref assignBy);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Add the shell colors
-            foreach (var color in theme.Colors)
-            {
-                if (ScopeMappings.Value.TryGetValue(color.Key.Trim(), out var colorKeyList))
-                {
-                    if (!TryGetColorValue(theme, color.Key, out string colorValue))
-                    {
-                        continue;
-                    }
-
-                    // calculate the actual border color for editor overlay colors
-                    if (OverlayMappings.Value.ContainsKey(color.Key) && TryGetColorValue(theme, OverlayMappings.Value[color.Key].Item2, out string backgroundColor))
-                    {
-                        colorValue = GetCompoundColor(colorValue, backgroundColor, OverlayMappings.Value[color.Key].Item1);
-                    }
-
-                    AssignShellColors(colorValue, colorKeyList, ref colorCategories);
-                }
-            }
-
-            return colorCategories;
-        }
-
-        private static bool TryGetColorValue(ThemeFileContract theme, string token, out string colorValue)
-        {
-            theme.Colors.TryGetValue(token, out colorValue);
-
-            string key = token;
-
-            while (colorValue == null)
-            {
-                if (VSCTokenFallback.Value.TryGetValue(key, out var fallbackToken))
-                {
-                    key = fallbackToken;
-                    theme.Colors.TryGetValue(key, out colorValue);
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            return colorValue != null;
-        }
-
-        /// <summary>
-        /// Compute what is the compound color of 2 overlayed colors with transparency
-        /// </summary>
-        /// <param name="VSOpacity">What is the opacity that VS will use when displaying this color</param>
-        /// <returns></returns>
-        private static string GetCompoundColor(string overlayColor, string baseColor, float VSOpacity = 1)
-        {
-            overlayColor = ReviseColor(overlayColor);
-            baseColor = ReviseColor(baseColor);
-            float overlayA = (float)System.Convert.ToInt32(overlayColor.Substring(0, 2), 16) / 255;
-            float overlayR = System.Convert.ToInt32(overlayColor.Substring(2, 2), 16);
-            float overlayG = System.Convert.ToInt32(overlayColor.Substring(4, 2), 16);
-            float overlayB = System.Convert.ToInt32(overlayColor.Substring(6, 2), 16);
-
-            float baseA = (float)System.Convert.ToInt32(baseColor.Substring(0, 2), 16) / 255;
-            float baseR = System.Convert.ToInt32(baseColor.Substring(2, 2), 16);
-            float baseG = System.Convert.ToInt32(baseColor.Substring(4, 2), 16);
-            float baseB = System.Convert.ToInt32(baseColor.Substring(6, 2), 16);
-
-            float R = (overlayA / VSOpacity) * overlayR + (1 - overlayA / VSOpacity) * baseA * baseR;
-            float G = (overlayA / VSOpacity) * overlayG + (1 - overlayA / VSOpacity) * baseA * baseG;
-            float B = (overlayA / VSOpacity) * overlayB + (1 - overlayA / VSOpacity) * baseA * baseB;
-
-            R = Math.Clamp(R, 0, 255);
-            G = Math.Clamp(G, 0, 255);
-            B = Math.Clamp(B, 0, 255);
-
-            return $"{(int)R:X2}{(int)G:X2}{(int)B:X2}FF";
-        }
-
-        private static void AssignEditorColors(ColorKey[] colorKeys,
-                                        string scope,
-                                        RuleContract ruleContract,
-                                        ref Dictionary<string, Dictionary<string, SettingsContract>> colorCategories,
-                                        ref Dictionary<string, Dictionary<string, string>> assignBy)
-        {
-            foreach (var colorKey in colorKeys)
-            {
-                if (!colorCategories.TryGetValue(colorKey.CategoryName, out var rulesList))
-                {
-                    rulesList = new Dictionary<string, SettingsContract>();
-                    colorCategories[colorKey.CategoryName] = rulesList;
-                }
-
-                if (!assignBy.TryGetValue(colorKey.CategoryName, out var assignList))
-                {
-                    assignList = new Dictionary<string, string>();
-                    assignBy[colorKey.CategoryName] = assignList;
-                }
-
-                if (rulesList.ContainsKey(colorKey.KeyName))
-                {
-                    if (scope.StartsWith(assignList[colorKey.KeyName]) && ruleContract.Settings.Foreground != null)
-                    {
-                        rulesList[colorKey.KeyName] = ruleContract.Settings;
-                        assignList[colorKey.KeyName] = scope;
-                    }
-                }
-                else
-                {
-                    rulesList.Add(colorKey.KeyName, ruleContract.Settings);
-                    assignList.Add(colorKey.KeyName, scope);
-                }
-            }
-        }
-
-        private static void AssignShellColors(string colorValue, ColorKey[] colorKeys, ref Dictionary<string, Dictionary<string, SettingsContract>> colorCategories)
-        {
-            foreach (var colorKey in colorKeys)
-            {
-                if (!colorCategories.TryGetValue(colorKey.CategoryName, out var rulesList))
-                {
-                    // token name to colors
-                    rulesList = new Dictionary<string, SettingsContract>();
-                    colorCategories[colorKey.CategoryName] = rulesList;
-                }
-
-                if (!rulesList.TryGetValue(colorKey.KeyName, out var colorSetting))
-                {
-                    colorSetting = new SettingsContract();
-                    rulesList.Add(colorKey.KeyName, colorSetting);
-                }
-
-                if (colorKey.isBackground)
-                {
-                    colorSetting.Background = colorValue;
-                }
-                else
-                {
-                    colorSetting.Foreground = colorValue;
-                }
-            }
-        }
-
-        #endregion Translate VS Theme
-
-        #region Write VS Theme
-
-        private static void WriteColor(StreamWriter writer, string colorKeyName, string foregroundColor, string backgroundColor)
-        {
-            writer.WriteLine($"            <Color Name=\"{colorKeyName}\">");
-
-            if (backgroundColor is not null)
-            {
-                writer.WriteLine($"                <Background Type=\"CT_RAW\" Source=\"{ReviseColor(backgroundColor)}\"/>");
-            }
-
-            if (foregroundColor is not null)
-            {
-                writer.WriteLine($"                <Foreground Type=\"CT_RAW\" Source=\"{ReviseColor(foregroundColor)}\"/>");
-            }
-
-            writer.WriteLine($"            </Color>");
-        }
-
-        private static string ReviseColor(string color)
-        {
-            var revisedColor = color.Trim('#');
-            switch (revisedColor.Length)
-            {
-                case 3:
-                    {
-                        string r = revisedColor.Substring(0, 1);
-                        string g = revisedColor.Substring(1, 1);
-                        string b = revisedColor.Substring(2, 1);
-                        revisedColor = string.Format("FF{0}{0}{1}{1}{2}{2}", r, g, b);
-                        break;
-                    }
-                case 4:
-                    {
-                        string r = revisedColor.Substring(0, 1);
-                        string g = revisedColor.Substring(1, 1);
-                        string b = revisedColor.Substring(2, 1);
-                        string a = revisedColor.Substring(3, 1);
-                        revisedColor = string.Format("{0}{0}{1}{1}{2}{2}{3}{3}", a, r, g, b);
-                        break;
-                    }
-                case 6:
-                    {
-                        revisedColor = $"FF{revisedColor}";
-                        break;
-                    }
-                case 8:
-                    {
-                        // go from RRGGBBAA to AARRGGBB
-                        revisedColor = string.Format("{0}{1}", revisedColor.Substring(6), revisedColor.Substring(0, 6));
-                        break;
-                    }
-                default:
-                    break;
-            }
-            return revisedColor;
-        }
-
-        #endregion Write VS Theme
-    }
-
-    internal sealed class ColorKey
-    {
-        public ColorKey(string categoryName, string keyName, string backgroundOrForeground)
-        {
-            this.CategoryName = categoryName;
-            this.KeyName = keyName;
-            this.Aspect = backgroundOrForeground;
-
-            if (backgroundOrForeground.Equals("Background", StringComparison.OrdinalIgnoreCase))
-            {
-                isBackground = true;
-            }
-            else
-            {
-                isBackground = false;
-            }
-        }
-
-        public string CategoryName { get; }
-
-        public string KeyName { get; }
-
-        public string Aspect { get; }
-
-        public bool isBackground { get; }
-
-        public override string ToString()
-        {
-            return this.CategoryName + "&" + this.KeyName + "&" + this.Aspect;
         }
     }
 }

--- a/ThemeConverter/ThemeConverter/Resources.Designer.cs
+++ b/ThemeConverter/ThemeConverter/Resources.Designer.cs
@@ -101,6 +101,15 @@ namespace ThemeConverter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Launching Visual Studio..
+        /// </summary>
+        internal static string LaunchingVS {
+            get {
+                return ResourceManager.GetString("LaunchingVS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No JSON file was found under the given directory..
         /// </summary>
         internal static string NoJSONFoundException {
@@ -119,6 +128,24 @@ namespace ThemeConverter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Running UpdateConfiguration..
+        /// </summary>
+        internal static string RunningUpdateConfiguration {
+            get {
+                return ResourceManager.GetString("RunningUpdateConfiguration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The devenv.exe file was not found at &quot;{0}&quot;..
+        /// </summary>
+        internal static string TargetDevEnvNotExistException {
+            get {
+                return ResourceManager.GetString("TargetDevEnvNotExistException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The installation path of the target VS. When specified, the converter will patch the converted pkgdef(s) to the target VS, run &quot;updateConfiguration&quot; and launch this VS. (e.g.: &quot;C:\Program Files\Microsoft Visual Studio\2022\Preview&quot;) OPTIONAL.
         /// </summary>
         internal static string TargetVS {
@@ -133,6 +160,15 @@ namespace ThemeConverter {
         internal static string TargetVSNotExistException {
             get {
                 return ResourceManager.GetString("TargetVSNotExistException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fatal error running &quot;devenv.exe /updateconfiguration&quot;..
+        /// </summary>
+        internal static string UpdateConfigurationException {
+            get {
+                return ResourceManager.GetString("UpdateConfigurationException", resourceCulture);
             }
         }
     }

--- a/ThemeConverter/ThemeConverter/Resources.resx
+++ b/ThemeConverter/ThemeConverter/Resources.resx
@@ -133,16 +133,28 @@ Arguments:</value>
   <data name="InputNotExistException" xml:space="preserve">
     <value>The input file or folder does not exist.</value>
   </data>
+  <data name="LaunchingVS" xml:space="preserve">
+    <value>Launching Visual Studio.</value>
+  </data>
   <data name="NoJSONFoundException" xml:space="preserve">
     <value>No JSON file was found under the given directory.</value>
   </data>
   <data name="Output" xml:space="preserve">
     <value>The output folder path of the converted pkgdef(s). When specified, the converter will save the converted pkgdef(s) to this path. If not specified, the output will be saved under the same directory of the input file/folder. OPTIONAL</value>
   </data>
+  <data name="RunningUpdateConfiguration" xml:space="preserve">
+    <value>Running UpdateConfiguration.</value>
+  </data>
+  <data name="TargetDevEnvNotExistException" xml:space="preserve">
+    <value>The devenv.exe file was not found at "{0}".</value>
+  </data>
   <data name="TargetVS" xml:space="preserve">
     <value>The installation path of the target VS. When specified, the converter will patch the converted pkgdef(s) to the target VS, run "updateConfiguration" and launch this VS. (e.g.: "C:\Program Files\Microsoft Visual Studio\2022\Preview") OPTIONAL</value>
   </data>
   <data name="TargetVSNotExistException" xml:space="preserve">
     <value>The target VS installation directory does not exist.</value>
+  </data>
+  <data name="UpdateConfigurationException" xml:space="preserve">
+    <value>Fatal error running "devenv.exe /updateconfiguration".</value>
   </data>
 </root>

--- a/ThemeConverter/ThemeConverterTests/ConversionTest.cs
+++ b/ThemeConverter/ThemeConverterTests/ConversionTest.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace ThemeConverterTests
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using FluentAssertions;
+    using ThemeConverter;
+    using Xunit;
+
+    public class ConversionTest
+    {
+        private static readonly string ResultsFolderPath = Path.Combine(Directory.GetCurrentDirectory(), "TestResults", DateTime.Now.ToString("yyyy-dd-MM-HHmmss"));
+        private static readonly string ThemesFolderPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestFiles");
+
+        // TODO: this is bare minimum to get infrastructure going
+        // - add a valid json theme
+        // - validate contents of generated pkgdef file, at least partially
+        //   - asserting exact file contents would make this impossible to maintain or trust
+        //     but we could at least validate the .pkgdef header and the various keys for known categories are present
+        // - converter is not really resilient when it comes to invalid files, sometimes wrong output without exception,
+        //   sometimes NRE...
+
+        [Fact]
+        public void Invalid_NoColors()
+        {
+            Assert.Throws<NullReferenceException>(() =>
+            {
+                ConvertTheme("Invalid_NoColors.json");
+            });
+        }
+
+        [Fact]
+        public void Invalid_MissingCriticalColors()
+        {
+            string pkgdefPath = ConvertTheme("Invalid_MissingCriticalColors.json");
+            File.Exists(pkgdefPath).Should().BeTrue();
+        }
+
+        private static string ConvertTheme(string testFileName)
+        {
+            return Converter.ConvertFile(Path.Combine(ThemesFolderPath, testFileName), ResultsFolderPath);
+        }
+    }
+}

--- a/ThemeConverter/ThemeConverterTests/DataValidationTest.cs
+++ b/ThemeConverter/ThemeConverterTests/DataValidationTest.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace ThemeConverterTests
+{
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using ThemeConverter;
+    using Xunit;
+
+    /// <summary>
+    /// Tests to ensure that our internal data files don't have inconsistencies (duplicates, etc).
+    /// </summary>
+    public class DataValidationTest
+    {
+        [Fact]
+        public void NoValidationError()
+        {
+            var errors = new List<string>();
+
+            Converter.ValidateDataFiles((error) => errors.Add(error));
+
+            errors.Should().BeEmpty();
+        }
+    }
+}

--- a/ThemeConverter/ThemeConverterTests/TestFiles/Invalid_MissingCriticalColors.json
+++ b/ThemeConverter/ThemeConverterTests/TestFiles/Invalid_MissingCriticalColors.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"type": "light",
+	"colors": {
+		"activityBar.border": "#219fd544",
+		"activityBar.foreground": "#99d0f7"
+	},
+	"tokenColors": [
+		{
+			"scope": [
+				"meta.paragraph.markdown",
+				"string.other.link.description.title.markdown"
+			],
+			"settings": {
+				"foreground": "#110000"
+			}
+		}
+	]
+}

--- a/ThemeConverter/ThemeConverterTests/TestFiles/Invalid_NoColors.json
+++ b/ThemeConverter/ThemeConverterTests/TestFiles/Invalid_NoColors.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"type": "light",
+	"colors": {
+	}
+}

--- a/ThemeConverter/ThemeConverterTests/ThemeConverterTests.csproj
+++ b/ThemeConverter/ThemeConverterTests/ThemeConverterTests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ThemeConverter\ThemeConverter.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="TestFiles\Invalid_MissingCriticalColors.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFiles\Invalid_NoColors.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
I've been wanting to do some cleanup for a while, here is some of it.

Program had grown to contain almost all the code. I have separated it in two, the logic to handle arguments, console input/output and VS deployment/startup remains in `Program`, and the conversion logic goes into `Converter`.

Removed that `ThemeName` global variable.

Removed console output from `ParseMappings`.

Moved some hard coded messages to string resources.

Added a test project so we can convert various valid and invalid themes, as well as ensure that our internal data files are valid. I just put a few tests in there as a starting point.

For the tests, `Converter` is a public type (the only one) with 2 public methods to convert a theme and validate our internal data files.

Some of the file handling code has changed slightly to make the `Converter` class more usable from both program and tests.

We'll update the pipeline later to run the new tests (but skip the older screenshot capture tests).