### PR TITLE
Always use colors from active title bar for VS title bar

### DIFF
--- a/ThemeConverter/ThemeConverter/TokenMappings.json
+++ b/ThemeConverter/ThemeConverter/TokenMappings.json
@@ -471,6 +471,7 @@
         "Environment&InactiveCaption&Background",
         "Environment&MainWindowActiveCaption&Background",
         "Environment&MainWindowCloudEnvironmentInactive&Background",
+        "Environment&MainWindowInactiveCaption&Background",
         "Environment&PanelSeparator&Background",
         "Environment&PanelSubGroupSeparator&Background",
         "Environment&PanelTitleBar&Background",
@@ -485,6 +486,7 @@
         "Environment&ProjectDesignerTabSepBottomGradientBegin&Background",
         "Environment&ProjectDesignerTabSepTopGradientEnd&Background",
         "Environment&TitleBarDragHandleActive&Background",
+        "Environment&TitleBarInactive&Background",
         "Environment&TitleBarInactiveGradientBegin&Background",
         "Environment&TitleBarInactiveGradientEnd&Background",
         "Environment&ToolboxSelectedHeadingBegin&Background",
@@ -521,6 +523,8 @@
         "Environment&CommandBarTextMouseDown&Background",
         "Environment&FileTabIndicatorTextSelectedInactive&Background",
         "Environment&MainWindowButtonActiveGlyph&Background",
+        "Environment&MainWindowButtonInactiveGlyph&Background",
+        "Environment&MainWindowInactiveCaption&Foreground",
         "Environment&TitleBarActive&Background"
       ]
     },
@@ -3753,15 +3757,11 @@
     {
       "VSC Token": "titleBar.inactiveBackground",
       "VS Token": [
-        "Environment&MainWindowInactiveCaption&Background",
-        "Environment&TitleBarInactive&Background"
       ]
     },
     {
       "VSC Token": "titleBar.inactiveForeground",
       "VS Token": [
-        "Environment&MainWindowInactiveCaption&Foreground",
-        "Environment&MainWindowButtonInactiveGlyph&Background"
       ]
     },
     {


### PR DESCRIPTION
The command bar background used colors from active title bar so that it looks smooth with the title bar when VS has focus. However when using compact menu and search bar, the menu bar is on top of the title bar - when VS loses focus, the title bar uses inactive background but the command bar still uses active titlebar background color causing the issue described.

Solution: Always use active title bar colors for VS title bar. (VS still can use product icon and focus border to differentiate whether it has focus or not)
Before (unfocused):
![image](https://user-images.githubusercontent.com/34032260/134221089-b6fba7eb-0945-4a1b-840f-8f277b47ee5f.png)
After (unfocused):
![image](https://user-images.githubusercontent.com/34032260/134221146-c96e026d-ed7a-4544-bc03-98aa17b674e7.png)
After (focused): 
![image](https://user-images.githubusercontent.com/34032260/134221225-094ab3db-b9fc-4bab-bd83-055a76659eb5.png)
