### PR TITLE
Improve Collapsed Region Text

### DIFF
--- a/ThemeConverter/ThemeConverter/TokenMappings.json
+++ b/ThemeConverter/ThemeConverter/TokenMappings.json
@@ -5,8 +5,7 @@
       "VS Token": [
         "Text Editor Language Service Items&Comment",
         "Roslyn Text Editor MEF Items&xml doc comment - delimiter",
-        "Roslyn Text Editor MEF Items&xml doc comment - text",
-        "Text Editor Language Service Items&Collapsible Text (Collapsed)"
+        "Roslyn Text Editor MEF Items&xml doc comment - text"
       ]
     },
     {
@@ -84,7 +83,8 @@
     {
       "VSC Token": "string.unquoted.preprocessor.message.cs",
       "VS Token": [
-        "Text Editor MEF Items&preprocessor text"
+        "Text Editor MEF Items&preprocessor text",
+        "Text Editor Text Marker Items&Collapsible Text (Collapsed)&Foreground"
       ]
     },
     {


### PR DESCRIPTION
This change is using the region name color (preprocessor text) for the collapsed text as in VSCode, because collapsing the code does not create a new overlay but rather shows the first line.
Note: collapsed text color is only read at VS start up, therefore, in order to see this change, you will need to first open VS, select your target theme, and then restart VS.
Before:
![image](https://user-images.githubusercontent.com/34032260/134599332-230f74b6-91cf-4671-b8cc-c13514643e88.png)
After: 
![image](https://user-images.githubusercontent.com/34032260/134599349-3b4eed3f-d233-4ed5-9e4f-a17947b79bfb.png)
Unfolded:
![image](https://user-images.githubusercontent.com/34032260/134599361-e5257bc8-fcd8-4460-b236-1c99e5fc6963.png)
VS Code:
![image](https://user-images.githubusercontent.com/34032260/134600400-33c72fcb-011a-450e-82d4-26957613ff56.png)
