### PR TITLE
Set product/file/assembly version from the pipeline.

### DIFF
--- a/ThemeConverter/ThemeConverter/Program.cs
+++ b/ThemeConverter/ThemeConverter/Program.cs
@@ -16,7 +16,7 @@ namespace ThemeConverter
         private const string PathToVSThemeFolder = @"Common7\IDE\CommonExtensions\Platform";
         private const string PathToVSExe = @"Common7\IDE\devenv.exe";
 
-        private static readonly string ProductVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        private static readonly string ProductVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
 
         static int Main(string[] args)
         {

--- a/ThemeConverter/ThemeConverter/ThemeConverter.csproj
+++ b/ThemeConverter/ThemeConverter/ThemeConverter.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>0.1.0</Version>
+    <Version Condition="'$(Version)'==''">0.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,14 @@ variables:
     value: Release
   - name: ProductBinariesFolder
     value: '$(System.DefaultWorkingDirectory)/ThemeConverter/ThemeConverter/bin/$(BuildConfiguration)/net5.0'
+  - name: VersionMajor
+    value: 0
+  - name: VersionMinor
+    value: 1
+  - name: AssemblyVersion
+    value: $(VersionMajor).$(VersionMinor).0.0
+  - name: ProductVersion
+    value: $(VersionMajor).$(VersionMinor).$(Build.BuildNumber).0
     
 jobs:
 - job: Build_And_Compliance
@@ -52,6 +60,7 @@ jobs:
       solution: $(SolutionFile)
       platform: $(Platform)
       configuration: $(BuildConfiguration)
+      msbuildArguments: /Property:Version=$(ProductVersion) /Property:FileVersion=$(ProductVersion) /Property:AssemblyVersion=$(AssemblyVersion)
     continueOnError: false    
       
   # Run component governance detection

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ variables:
   - name: AssemblyVersion
     value: $(VersionMajor).$(VersionMinor).0.0
   - name: ProductVersion
-    value: $(VersionMajor).$(VersionMinor).$(Build.BuildNumber).0
+    value: $(VersionMajor).$(VersionMinor).$(Build.BuildNumber)
     
 jobs:
 - job: Build_And_Compliance

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,7 +157,7 @@ jobs:
       rootFolderOrFile: '$(ProductBinariesFolder)'
       includeRootFolder: true
       archiveType: 'zip'
-      archiveFile: '$(Build.StagingDirectory)/ThemeConverter-$(Build.BuildNumber).zip' 
+      archiveFile: '$(Build.StagingDirectory)/ThemeConverter-$(VersionMajor).$(VersionMinor).$(Build.BuildNumber).zip' 
       replaceExistingArchive: true
 
   # Publish staging artifacts


### PR DESCRIPTION
Include the azure pipeline generated build number in the product/file version, but not assembly version.
Display the file version in the help instead of assembly version (so we can see the build number).