### PR TITLE
Improve mappings for razor files

### DIFF
--- a/ThemeConverter/ThemeConverter/CategoryGuid.json
+++ b/ThemeConverter/ThemeConverter/CategoryGuid.json
@@ -72,5 +72,6 @@
   "TeamExplorer": "{4aff231b-f28a-44f0-a66b-1beeb17cb920}",
   "VersionControl": "{6be84f44-74e4-4e5f-aee9-1b930f431375}",
   "WorkItemEditor": "{2138d120-456d-425e-80b5-88d2401fca23}",
-  "PackageManifestEditor": "{3f27d653-86e6-4a04-adb6-a35efa6c8f05}"
+  "PackageManifestEditor": "{3f27d653-86e6-4a04-adb6-a35efa6c8f05}",
+  "WebEditor": "{75a05685-00a8-4ded-bae5-e7a50bfa929a}"
 }

--- a/ThemeConverter/ThemeConverter/TokenMappings.json
+++ b/ThemeConverter/ThemeConverter/TokenMappings.json
@@ -33,6 +33,20 @@
       ]
     },
     {
+      "VSC Token": "entity.name.class.element.taghelper",
+      "VS Token": [
+        "WebEditor&RazorTagHelperElement",
+        "WebEditor&RazorComponentElement"
+      ]
+    },
+    { 
+      "VSC Token": "entity.name.class.attribute.taghelper",
+      "VS Token": [
+        "WebEditor&RazorTagHelperAttribute",
+        "WebEditor&RazorComponentAttribute"
+      ]
+    },
+    {
       "VSC Token": "entity.name.tag.html",
       "VS Token": [
         "Text Editor MEF Items&HTML Element Name"
@@ -159,7 +173,12 @@
       "VS Token": [
         "Text Editor Language Service Items&String",
         "Roslyn Text Editor MEF Items&string - verbatim",
-        "Roslyn Text Editor MEF Items&xml doc comment - attribute value",
+        "Roslyn Text Editor MEF Items&xml doc comment - attribute value"
+      ]
+    },
+    {
+      "VSC Token": "string.quoted.double.html",
+      "VS Token":[
         "Text Editor MEF Items&HTML Attribute Value"
       ]
     },


### PR DESCRIPTION
The original theme was using semantic highlighting, but from the generated json, seems like the semantic tokens were not captured? This change is improving the textmate mapping only. Supporting semantic mapping needs more investigation.
![image](https://user-images.githubusercontent.com/34032260/135919035-77d782f6-181d-4cdb-9773-10e057ccb569.png)
