### PR TITLE
Use foreground color for info bar hyperlink

### DIFF
--- a/ThemeConverter/ThemeConverter/TokenMappings.json
+++ b/ThemeConverter/ThemeConverter/TokenMappings.json
@@ -1381,15 +1381,15 @@
     {
       "VSC Token": "banner.foreground",
       "VS Token": [
-        "InfoBar&InfoBarBackground&Foreground"
+        "InfoBar&InfoBarBackground&Foreground",
+        "InfoBar&Hyperlink&Foreground",
+        "InfoBar&HyperlinkMouseDown&Foreground",
+        "InfoBar&HyperlinkMouseOver&Foreground"
       ]
     },
     {
       "VSC Token": "banner.iconForeground",
       "VS Token": [
-        "InfoBar&Hyperlink&Foreground",
-        "InfoBar&HyperlinkMouseDown&Foreground",
-        "InfoBar&HyperlinkMouseOver&Foreground"
       ]
     },
     {


### PR DESCRIPTION
Pending design review.
VS Code:
![image](https://user-images.githubusercontent.com/34032260/138374764-5750c050-4ee5-417c-8eb9-c9018e6eae8b.png)
VS Hovered:
![image](https://user-images.githubusercontent.com/34032260/138374779-c5982490-97c5-4ff8-8d7a-8ba43f9df738.png)
VS Not Hovered:
![image](https://user-images.githubusercontent.com/34032260/138374798-4a70e568-10d5-4df5-bac3-b4d2b6f3b3b5.png)

VS Code always shows an underscore for links, but VS only shows when hovered and when it is not hovered, the link looks the same as normal text, wondering if this is ok?