### PR TITLE
Support VSC opacity

### DIFF
--- a/ThemeConverter/ThemeConverter/Converter.cs
+++ b/ThemeConverter/ThemeConverter/Converter.cs
@@ -458,7 +458,7 @@ namespace ThemeConverter
 
     internal sealed class ColorKey
     {
-        public ColorKey(string categoryName, string keyName, string backgroundOrForeground, string? foregroundOpacity = null, string? vscBackgorund = null)
+        public ColorKey(string categoryName, string keyName, string backgroundOrForeground, string? foregroundOpacity = null, string? vscBackground = null)
         {
             this.CategoryName = categoryName;
             this.KeyName = keyName;
@@ -473,8 +473,8 @@ namespace ThemeConverter
                 isBackground = false;
             }
 
-            this.ForegroundOpacity = foregroundOpacity == null ? null : float.Parse(foregroundOpacity, CultureInfo.InvariantCulture.NumberFormat); ;
-            this.VSCBackground = vscBackgorund;
+            this.ForegroundOpacity = foregroundOpacity == null ? null : float.Parse(foregroundOpacity, CultureInfo.InvariantCulture.NumberFormat);
+            this.VSCBackground = vscBackground;
         }
 
         public string CategoryName { get; }

--- a/ThemeConverter/ThemeConverter/ParseMapping.cs
+++ b/ThemeConverter/ThemeConverter/ParseMapping.cs
@@ -69,15 +69,24 @@ namespace ThemeConverter
                 {
                     string[] colorKey = VSToken.ToString()?.Split("&");
                     ColorKey newColorKey;
-                    if (colorKey.Length > 2)
+                    switch(colorKey.Length)
                     {
-                        newColorKey = new ColorKey(colorKey[0], colorKey[1], colorKey[2]);
+                        case 2: // category & token name (by default foreground)
+                            newColorKey = new ColorKey(colorKey[0], colorKey[1], "Foreground");
+                            break;
+                        case 3: // category & token name & aspect
+                            newColorKey = new ColorKey(colorKey[0], colorKey[1], colorKey[2]);
+                            break;
+                        case 4: // category & token name & vsc opacity & vscode background
+                            newColorKey = new ColorKey(colorKey[0], colorKey[1], "Foreground", colorKey[2], colorKey[3]);
+                            break;
+                        case 5: // category & token name & aspect & vsc opacity & vscode background
+                            newColorKey = new ColorKey(colorKey[0], colorKey[1], colorKey[2], colorKey[3], colorKey[4]);
+                            break;
+                        default:
+                            throw new Exception("Invalid mapping format");
                     }
-                    else
-                    {
-                        // if not specified, default to foreground
-                        newColorKey = new ColorKey(colorKey[0], colorKey[1], "Foreground");
-                    }
+
                     values.Add(newColorKey);
                     MappedVSTokens.Add(string.Format("{0}&{1}&{2}", newColorKey.CategoryName, newColorKey.KeyName, newColorKey.Aspect));
                 }

--- a/ThemeConverter/ThemeConverter/TokenMappings.json
+++ b/ThemeConverter/ThemeConverter/TokenMappings.json
@@ -2758,7 +2758,7 @@
         "Environment&CommandBarMenuSubmenuGlyph&Background",
         "Environment&CommandBarSplitButtonGlyph&Background",
         "Environment&CommandBarTextActive&Background", //
-        "Environment&CommandBarTextInactive&Background",
+        "Environment&CommandBarTextInactive&Background&0.4&menu.background",
         "UserInformation&ErrorText&Background",
         "UserInformation&IDCardInactiveText&Background",
         "UserInformation&IDCardMinimalModeInactiveWindowText&Background",


### PR DESCRIPTION
For disabled menu text, VSC will apply a 0.4 opacity to the foreground. Adding support for calculating the actual color.

Before: 
<img width="203" alt="image" src="https://user-images.githubusercontent.com/34032260/166154518-565635df-8995-4193-9674-2c3692565158.png">

After:
<img width="212" alt="image" src="https://user-images.githubusercontent.com/34032260/166154505-a7308c43-4b41-43af-9ffc-d603a205ba2c.png">
