### PR TITLE
Use vsc tab background for tab border

### DIFF
--- a/ThemeConverter/ThemeConverter/TokenMappings.json
+++ b/ThemeConverter/ThemeConverter/TokenMappings.json
@@ -599,7 +599,6 @@
     {
       "VSC Token": "tab.activeBorder",
       "VS Token": [
-        "Environment&FileTabDocumentBorderBackground&Background" //
       ]
     },
     {
@@ -608,6 +607,7 @@
         "Cider&TabItem&Background",
         "Cider&TabItemDisabled&Background",
         "Environment&FileTabBackground&Background",
+        "Environment&FileTabDocumentBorderBackground&Background", //
         "Environment&FileTabInactiveDocumentBorderBackground&Background",
         "Environment&FileTabInactiveGradientBottom&Background",
         "Environment&FileTabInactiveGradientTop&Background",

--- a/ThemeConverter/ThemeConverter/VSCTokenFallback.json
+++ b/ThemeConverter/ThemeConverter/VSCTokenFallback.json
@@ -18,7 +18,7 @@
   "sideBarSectionHeader.foreground": "foreground",
   "sideBarTitle.foreground": "sideBar.foreground",
   "tab.activeBorder": "tab.activeBackground",
-  "tab.activeBorderTop": "tab.activeBackground",
+  "tab.activeBorderTop": "tab.activeBorder",
   "tab.border": "tab.inactiveBackground",
   "tab.hoverBackground": "tab.inactiveBackground",
   "editor.selectionForeground": "editor.foreground",


### PR DESCRIPTION
As VSC does not have this divider between file tabs and the editor area, use the tab.inactivebackground for this line to minimize the distraction.
After:
![image](https://user-images.githubusercontent.com/34032260/172444235-1d991a95-c0ce-440f-b60c-3a0569b62fb1.png)
